### PR TITLE
Add cafe menu section to landing page

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,306 @@
+:root {
+    --bg: #f7f4f1;
+    --accent: #5a381e;
+    --accent-light: #b2825e;
+    --text: #2b221b;
+    --muted: #7a6c60;
+    --surface: #ffffff;
+    --surface-alt: #ece5dd;
+    --radius: 16px;
+    --transition: 0.2s ease;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', 'Segoe UI', sans-serif;
+    background-color: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+}
+
+.hero {
+    position: relative;
+    padding: 160px 0 120px;
+    background: linear-gradient(135deg, rgba(90, 56, 30, 0.85), rgba(26, 16, 9, 0.85)),
+        url('https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1600&q=80') center/cover;
+    color: #fff;
+    overflow: hidden;
+}
+
+.hero__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.1));
+}
+
+.hero__content {
+    position: relative;
+    max-width: 600px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.hero__eyebrow {
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
+    margin-bottom: 16px;
+}
+
+.hero__title {
+    font-size: clamp(2.8rem, 6vw, 4rem);
+    font-weight: 600;
+    margin-bottom: 16px;
+}
+
+.hero__subtitle {
+    font-size: 1.125rem;
+    margin-bottom: 24px;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.hero__cta {
+    display: inline-block;
+    background-color: #fff;
+    color: var(--accent);
+    padding: 14px 28px;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.hero__cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.hero__info {
+    position: relative;
+    margin: 60px auto 0;
+    max-width: 960px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 24px;
+    background-color: rgba(255, 255, 255, 0.08);
+    padding: 24px;
+    border-radius: var(--radius);
+    backdrop-filter: blur(6px);
+}
+
+.label {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.65);
+    margin-bottom: 6px;
+}
+
+.phone {
+    font-weight: 600;
+    text-decoration: none;
+    color: inherit;
+}
+
+main {
+    background-color: var(--bg);
+}
+
+.section {
+    padding: 80px 0;
+}
+
+.section--alt {
+    background-color: var(--surface-alt);
+}
+
+.container {
+    width: min(960px, 90vw);
+    margin: 0 auto;
+}
+
+.section h2 {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    margin-bottom: 32px;
+}
+
+.section__lead {
+    max-width: 620px;
+    margin-bottom: 36px;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.card {
+    background-color: var(--surface);
+    padding: 28px;
+    border-radius: var(--radius);
+    box-shadow: 0 10px 30px rgba(34, 20, 13, 0.08);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 20px 40px rgba(34, 20, 13, 0.12);
+}
+
+.card h3 {
+    margin-bottom: 12px;
+    font-size: 1.3rem;
+    color: var(--accent);
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.menu-card {
+    background-color: var(--surface);
+    padding: 28px;
+    border-radius: var(--radius);
+    box-shadow: 0 12px 28px rgba(34, 20, 13, 0.08);
+    display: grid;
+    gap: 18px;
+}
+
+.menu-card h3 {
+    font-size: 1.2rem;
+    color: var(--accent);
+}
+
+.menu-list {
+    list-style: none;
+    display: grid;
+    gap: 12px;
+}
+
+.menu-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 1rem;
+}
+
+.menu-list span:last-child {
+    color: var(--accent-light);
+    font-weight: 600;
+}
+
+.list {
+    list-style: none;
+    display: grid;
+    gap: 12px;
+    font-size: 1.05rem;
+}
+
+.contact {
+    display: grid;
+    gap: 48px;
+    align-items: start;
+}
+
+@media (min-width: 768px) {
+    .contact {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+.contact__phone {
+    margin-top: 24px;
+    padding: 16px;
+    border-left: 4px solid var(--accent-light);
+    background-color: rgba(178, 130, 94, 0.15);
+    border-radius: var(--radius);
+}
+
+.form {
+    background-color: var(--surface);
+    padding: 32px;
+    border-radius: var(--radius);
+    box-shadow: 0 12px 34px rgba(34, 20, 13, 0.08);
+    display: grid;
+    gap: 20px;
+}
+
+.form__field {
+    display: grid;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.form__field input,
+.form__field textarea {
+    width: 100%;
+    padding: 12px 14px;
+    border: 1px solid rgba(90, 56, 30, 0.2);
+    border-radius: 12px;
+    font-size: 1rem;
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form__field input:focus,
+.form__field textarea:focus {
+    outline: none;
+    border-color: var(--accent-light);
+    box-shadow: 0 0 0 4px rgba(178, 130, 94, 0.25);
+}
+
+.form__submit {
+    background-color: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 14px 24px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.form__submit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(90, 56, 30, 0.25);
+}
+
+.footer {
+    background-color: #15100c;
+    color: rgba(255, 255, 255, 0.7);
+    padding: 40px 0;
+}
+
+.footer__inner {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+    text-align: center;
+}
+
+.footer a {
+    color: rgba(255, 255, 255, 0.85);
+    text-decoration: none;
+}
+
+.footer a:hover {
+    text-decoration: underline;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Кофейня "Тихая Обжарка"</title>
+    <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+    <header class="hero">
+        <div class="hero__overlay"></div>
+        <div class="hero__content">
+            <p class="hero__eyebrow">Городская кофейня</p>
+            <h1 class="hero__title">Тихая Обжарка</h1>
+            <p class="hero__subtitle">Мы заботимся о каждом зерне и каждом госте.</p>
+            <a class="hero__cta" href="#contact">Забронировать столик</a>
+        </div>
+        <div class="hero__info">
+            <div>
+                <span class="label">Адрес</span>
+                <p>ул. Ароматная, 12</p>
+            </div>
+            <div>
+                <span class="label">Телефон</span>
+                <a class="phone" href="tel:+74951234567">+7 (495) 123-45-67</a>
+            </div>
+            <div>
+                <span class="label">Часы работы</span>
+                <p>Каждый день 08:00–22:00</p>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="about">
+            <div class="container">
+                <h2>Почему гости выбирают нас</h2>
+                <div class="feature-grid">
+                    <article class="card">
+                        <h3>Свежая обжарка</h3>
+                        <p>Мы обжариваем кофейные зерна малыми партиями каждую неделю, чтобы сохранить аромат и вкус.</p>
+                    </article>
+                    <article class="card">
+                        <h3>Авторские напитки</h3>
+                        <p>Бариста готовят авторские напитки и сезонные лимонады на основе домашних сиропов.</p>
+                    </article>
+                    <article class="card">
+                        <h3>Тихая атмосфера</h3>
+                        <p>Лаконичный интерьер и мягкое освещение помогут сосредоточиться на беседе или работе.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--alt" id="menu">
+            <div class="container">
+                <h2>Меню</h2>
+                <p class="section__lead">Мы собрали любимые напитки гостей и несколько сезонных позиций, которые отлично раскрывают вкус свежей обжарки.</p>
+                <div class="menu-grid">
+                    <article class="menu-card">
+                        <h3>Эспрессо-бар</h3>
+                        <ul class="menu-list">
+                            <li><span>Эспрессо</span><span>150 ₽</span></li>
+                            <li><span>Доппио</span><span>210 ₽</span></li>
+                            <li><span>Американо</span><span>190 ₽</span></li>
+                            <li><span>Флэт уайт</span><span>260 ₽</span></li>
+                        </ul>
+                    </article>
+                    <article class="menu-card">
+                        <h3>Авторские напитки</h3>
+                        <ul class="menu-list">
+                            <li><span>Солёная карамель</span><span>290 ₽</span></li>
+                            <li><span>Лавандовый раф</span><span>310 ₽</span></li>
+                            <li><span>Холодный брют-тоник</span><span>280 ₽</span></li>
+                            <li><span>Миндальное капучино</span><span>270 ₽</span></li>
+                        </ul>
+                    </article>
+                    <article class="menu-card">
+                        <h3>Десерты</h3>
+                        <ul class="menu-list">
+                            <li><span>Чизкейк с карамелью</span><span>250 ₽</span></li>
+                            <li><span>Шоколадный фондан</span><span>270 ₽</span></li>
+                            <li><span>Песочное печенье</span><span>140 ₽</span></li>
+                            <li><span>Грушевый тарт</span><span>230 ₽</span></li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="contact">
+            <div class="container contact">
+                <div>
+                    <h2>Оставьте заявку</h2>
+                    <p>Заполните форму, и мы свяжемся с вами в течение дня, чтобы обсудить детали бронирования или сотрудничества.</p>
+                    <div class="contact__phone">
+                        <span class="label">Телефон для связи</span>
+                        <a class="phone" href="tel:+74951234567">+7 (495) 123-45-67</a>
+                    </div>
+                </div>
+                <form class="form" action="#" method="post">
+                    <label class="form__field">
+                        <span>Имя</span>
+                        <input type="text" name="name" placeholder="Ваше имя" required>
+                    </label>
+                    <label class="form__field">
+                        <span>Телефон</span>
+                        <input type="tel" name="phone" placeholder="+7 (___) ___-__-__" required>
+                    </label>
+                    <label class="form__field">
+                        <span>Комментарий</span>
+                        <textarea name="message" rows="4" placeholder="Чем мы можем помочь?" required></textarea>
+                    </label>
+                    <button type="submit" class="form__submit">Отправить</button>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container footer__inner">
+            <p>© 2024 Тихая Обжарка. Все права защищены.</p>
+            <p><a href="mailto:hello@quietroast.ru">hello@quietroast.ru</a></p>
+        </div>
+    </footer>
+
+    <!-- Пример места для тестовых скриптов -->
+    <script>
+        window.TEST_SITE_READY = true;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the testing-scripts section with a cafe menu featuring signature drinks and desserts
- add supporting styles for the menu layout and descriptive lead text

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68db82d095b8832b9a8a1ca8859fe6e9